### PR TITLE
fix links to match markdown anchors

### DIFF
--- a/.github/workflows/bib2readme.py
+++ b/.github/workflows/bib2readme.py
@@ -5,6 +5,8 @@ from pybtex.database import parse_file
 from pybtex.scanner import PybtexSyntaxError
 from pylatexenc.latex2text import LatexNodes2Text
 
+from slugify import slugify
+
 # Define the categories to be printed in the README
 VALID_CATEGORIES = {
     "overview": "Overview Articles",
@@ -188,7 +190,7 @@ def create_readme(entries_by_category: Dict[str, List[Entry]]) -> str:
     readme_content += "## Contents\n\n"
     for category_key, category_value in VALID_CATEGORIES.items():
         if category_key in entries_by_category:
-            readme_content += f"- [{category_value}](#{category_key})\n"
+            readme_content += f"- [{category_value}](#{slugify(category_value)})\n"
     readme_content += "\n\n"
 
     # Add Sections

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,2 +1,3 @@
 pybtex==0.24.0
 pylatexenc==2.10
+python-slugify==8.0.4


### PR DESCRIPTION
Use slugified title instead of category names to make the links work